### PR TITLE
Ensure session id is a string

### DIFF
--- a/flask_memcache_session/session.py
+++ b/flask_memcache_session/session.py
@@ -7,7 +7,7 @@ class Session(SessionInterface):
     session_class = SessionData
 
     def open_session(self, app, request):
-        self.cookie_session_id = request.cookies.get(app.session_cookie_name, None)
+        self.cookie_session_id = request.cookies.get(app.session_cookie_name, type=str)
         self.session_new = False
         if self.cookie_session_id is None:
             self.cookie_session_id = os.urandom(40).encode('hex')


### PR DESCRIPTION
Cookie values are returned as unicode which messes up some memcache client implementations (such as [bmemcached](https://python-binary-memcached.readthedocs.org/en/latest/intro/)).

This change simply requests the session cookie be returned as a string.
