### PR TITLE
Fixed import error in python3

### DIFF
--- a/flask_memcache_session/__init__.py
+++ b/flask_memcache_session/__init__.py
@@ -1,1 +1,1 @@
-from session import Session
+from .session import Session


### PR DESCRIPTION
Trying to run the example code failed for me with error

> from session import Session
> ImportError: No module named 'session'

This is because session wasn't a package but a file. Adding "." to the import makes the import local and should fix the problem (does so on my local machine).